### PR TITLE
Fixed a problem with the error message when mas(max_age) is not an integer.

### DIFF
--- a/authorization_endpoint.go
+++ b/authorization_endpoint.go
@@ -315,7 +315,7 @@ func (a *AuthorizationEndpoint) HandleRequest(w http.ResponseWriter,
 				"'max_age' is not an integer value."))
 
 			rh.Error(ruri, "invalid_request",
-				fmt.Sprintf("'max_age' should be integer", mas),
+				fmt.Sprintf("'max_age' should be integer: '%s'", mas),
 				state)
 			return false
 		}


### PR DESCRIPTION
Fixed a problem with the error message when mas(max_age) is not an integer.