### PR TITLE
Fixed wrong combination of response_type and response_mode

### DIFF
--- a/response_mode/util.go
+++ b/response_mode/util.go
@@ -13,9 +13,9 @@ func Validate(mode string) bool {
 func securityLevelForMode(mode string) int {
 	switch mode {
 	case Query:
-		return 1
-	case Fragment:
 		return 0
+	case Fragment:
+		return 1
 	case FormPost:
 		return 2
 	}

--- a/response_mode/util_test.go
+++ b/response_mode/util_test.go
@@ -1,0 +1,30 @@
+package response_mode
+
+import (
+	"testing"
+)
+
+func TestCompareSecurityLevel(t *testing.T) {
+	defaultRM := Query // flow.AuthorizationCode
+	if !CompareSecurityLevel(Query, defaultRM) {
+		t.Error("CompareSecurityLevel should be ok")
+	}
+	if !CompareSecurityLevel(Fragment, defaultRM) {
+		t.Error("CompareSecurityLevel should be ok")
+	}
+	if !CompareSecurityLevel(FormPost, defaultRM) {
+		t.Error("CompareSecurityLevel should be ok")
+	}
+
+	defaultRM = Fragment // flow.Implicit or flow.Hybrid
+	if CompareSecurityLevel(Query, defaultRM) {
+		t.Error("CompareSecurityLevel should not be ok")
+	}
+	if !CompareSecurityLevel(Fragment, defaultRM) {
+		t.Error("CompareSecurityLevel should be ok")
+	}
+	if !CompareSecurityLevel(FormPost, defaultRM) {
+		t.Error("CompareSecurityLevel should be ok")
+	}
+}
+


### PR DESCRIPTION
I think the combination of response_type and response_mode is wrong, so I fixed it.

https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Combinations
> This section defines combinations of the values code, token, and id_token, which are each individually registered Response Types.

> The default Response Mode for this Response Type is the fragment encoding and the query encoding MUST NOT be used.