### PR TITLE
[Fix] Connector to consider `&` in addition to `?` and `#`.

### DIFF
--- a/authorization/response.go
+++ b/authorization/response.go
@@ -32,14 +32,27 @@ type (
 	}
 )
 
-func (t ResponseParamType) Connector() string {
+func (t ResponseParamType) Connector(uri string) string {
+	u, _ := url.Parse(uri)
 	switch t {
 	case ParamTypeQuery:
-		return "?"
+		if len(u.RawQuery) == 0 {
+			return "?"
+		} else {
+			return "&"
+		}
 	case ParamTypeFragment:
-		return "#"
+		if len(u.Fragment) == 0 {
+			return "#"
+		} else {
+			return "&"
+		}
 	default:
-		return "?"
+		if len(u.RawQuery) == 0 {
+			return "?"
+		} else {
+			return "&"
+		}
 	}
 }
 
@@ -69,7 +82,7 @@ func (h *RedirectResponseHandler) Success(uri string, params map[string]string) 
 	for k, v := range params {
 		values.Add(k, v)
 	}
-	u := fmt.Sprintf("%s%s%s", uri, h.pt.Connector(), values.Encode())
+	u := fmt.Sprintf("%s%s%s", uri, h.pt.Connector(uri), values.Encode())
 	http.Redirect(h.w, h.r, u, http.StatusFound)
 }
 
@@ -82,7 +95,7 @@ func (h *RedirectResponseHandler) Error(uri, typ, desc, state string) {
 	if state != "" {
 		params.Add("state", state)
 	}
-	u := fmt.Sprintf("%s%s%s", uri, h.pt.Connector(), params.Encode())
+	u := fmt.Sprintf("%s%s%s", uri, h.pt.Connector(uri), params.Encode())
 	http.Redirect(h.w, h.r, u, http.StatusFound)
 }
 

--- a/authorization/response_test.go
+++ b/authorization/response_test.go
@@ -1,0 +1,21 @@
+package authorization
+
+import (
+	"testing"
+)
+
+func TestConnector(t *testing.T) {
+	testConnector(t, ParamTypeQuery, "https://example.com", "?")
+	testConnector(t, ParamTypeQuery, "https://example.com?foo=bar", "&")
+	testConnector(t, ParamTypeFragment, "https://example.com", "#")
+	testConnector(t, ParamTypeFragment, "https://example.com#foo=bar", "&")
+}
+
+func testConnector(t *testing.T, p ResponseParamType, uri, expected string) {
+	c := &RedirectResponseHandler{w: nil, r: nil, pt: p}
+	actual := c.pt.Connector(uri)
+
+	if actual != expected {
+		t.Errorf("Connector for [%s]\n - got: %v\n - want: %v\n", uri, actual, expected)
+	}
+}


### PR DESCRIPTION
I want to support redirect_uri such as `http://example.com?target=Office`.

### before
`http://example.com?target=Office?code=xxxx&state=yyy`

### after (This PR)
`http://example.com?target=Office&code=xxxx&state=yyy`
