### PR TITLE
Fixed build failure in lestrrat/go-jwx due to "Rewrite JWK " changes.

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -15,11 +15,11 @@ import (
 func PublicKeysJWK(keys map[string]*rsa.PublicKey) ([]byte, error) {
 	set := &jwk.Set{}
 	for kid, key := range keys {
-		rk, err := jwk.NewRsaPublicKey(key)
+		rk, err := jwk.New(key)
 		if err != nil {
 			return nil, err
 		}
-		rk.KeyID = kid
+		rk.Set(jwk.KeyIDKey, kid)
 		set.Keys = append(set.Keys, rk)
 	}
 	body, err := json.MarshalIndent(set, "", "    ")
@@ -38,11 +38,12 @@ func LoadPublicKeyFromJWK(jwkString, kid string) (*rsa.PublicKey, error) {
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("indicated key id not found")
 	} else {
-		pk, ok := keys[0].(*jwk.RsaPublicKey)
+		pk, ok := keys[0].(*jwk.RSAPublicKey)
 		if !ok {
 			return nil, errors.New("indicated key is not a public key")
 		}
-		return pk.PublicKey()
+		rsaKey, err := pk.Materialize()
+		return rsaKey.(*rsa.PublicKey), err
 	}
 }
 

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -38,6 +38,31 @@ oqxJsRC0l1ybcs6o0QIDAQAB
 	}
 }
 
+func TestLoadPublicKeyFromJWK(t *testing.T) {
+	jwkString := `{
+    "keys": [
+        {
+            "e": "AQAB",
+            "kid": "my_key_version",
+            "kty": "RSA",
+            "n": "sxclFH1RsjAmxu2CMIKOF3ahI4YYCGSeCq-1SsCHOxfsdA6AZ4juroVOh1cTD4m8UgyBkCB6MT_RyTxhdV5RLexDMHsG-UXJLt96_tkAhE0ZkDMOvHmVGanbYMtSRQhbBVHDMHFXH06l1NNFBHrx_URQR6KsSbEQtJdcm3LOqNE"
+        }
+    ]
+}`
+	pk, err := LoadPublicKeyFromJWK(jwkString, "my_key_version")
+	if err != nil {
+		t.Error("LoadPublicKeyFromJWK should not fail")
+	}
+	expected_E := 65537
+	if pk.E != expected_E {
+		t.Errorf("JWK:\n - got: %v\n - want: %v\n", pk.E, expected_E)
+	}
+	expected_N := "125761562406782462307976315837545894753596483913155629630845400922907150365823375233335966135888915653473579854535859095871067725653279636082966210229051847528843249278196841298129937769379799128054212839147877967083771260968564646064234593247897648494467957173841524414818545360053846191075030561605257439441"
+	if pk.N.String() != expected_N {
+		t.Errorf("JWK:\n - got: %v\n - want: %v\n", pk.N.String(), expected_N)
+	}
+}
+
 func TestLoadPrivateKey(t *testing.T) {
 
 	_, err := LoadPrivateKeyFromText("INVALID_PEM")

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -26,9 +26,9 @@ oqxJsRC0l1ybcs6o0QIDAQAB
 	expected := `{
     "keys": [
         {
+            "e": "AQAB",
             "kid": "my_key_version",
             "kty": "RSA",
-            "e": "AQAB",
             "n": "sxclFH1RsjAmxu2CMIKOF3ahI4YYCGSeCq-1SsCHOxfsdA6AZ4juroVOh1cTD4m8UgyBkCB6MT_RyTxhdV5RLexDMHsG-UXJLt96_tkAhE0ZkDMOvHmVGanbYMtSRQhbBVHDMHFXH06l1NNFBHrx_URQR6KsSbEQtJdcm3LOqNE"
         }
     ]

--- a/jwk_endpoint_test.go
+++ b/jwk_endpoint_test.go
@@ -34,9 +34,9 @@ oqxJsRC0l1ybcs6o0QIDAQAB
 	expected := `{
     "keys": [
         {
+            "e": "AQAB",
             "kid": "my_key_id",
             "kty": "RSA",
-            "e": "AQAB",
             "n": "sxclFH1RsjAmxu2CMIKOF3ahI4YYCGSeCq-1SsCHOxfsdA6AZ4juroVOh1cTD4m8UgyBkCB6MT_RyTxhdV5RLexDMHsG-UXJLt96_tkAhE0ZkDMOvHmVGanbYMtSRQhbBVHDMHFXH06l1NNFBHrx_URQR6KsSbEQtJdcm3LOqNE"
         }
     ]


### PR DESCRIPTION
1. use go mod
```
$ go mod init github.com/lyokato/goidc
$ go mod tidy
```

2. build failed
```
$ go build
crypto/key.go:18:18: undefined: jwk.NewRsaPublicKey
crypto/key.go:41:27: undefined: jwk.RsaPublicKey
```

See: https://github.com/lestrrat/go-jwx/commit/72867763d6cbf58bf3d7b4c8a40e971ddd69325c