### PR TITLE
Change from github.com/dgrijalva/jwt-go to github.com/golang-jwt/jwt.

### DIFF
--- a/assertion/error.go
+++ b/assertion/error.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/lyokato/goidc/bridge"
 	"github.com/lyokato/goidc/log"
 	oer "github.com/lyokato/goidc/oauth_error"

--- a/authorization_endpoint.go
+++ b/authorization_endpoint.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/lyokato/goidc/authorization"
 	"github.com/lyokato/goidc/bridge"
 	"github.com/lyokato/goidc/flow"

--- a/grant/jwt.go
+++ b/grant/jwt.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 
 	"github.com/lyokato/goidc/assertion"
 	"github.com/lyokato/goidc/bridge"

--- a/id_token/id_token.go
+++ b/id_token/id_token.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 )
 
 func Hash(alg string, token string) (string, error) {

--- a/test_helper/http_client.go
+++ b/test_helper/http_client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/lyokato/goidc/crypto"
 )
 

--- a/token_endpoint.go
+++ b/token_endpoint.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/lyokato/goidc/assertion"
 	"github.com/lyokato/goidc/bridge"
 	"github.com/lyokato/goidc/grant"

--- a/token_endpoint_assertion_test.go
+++ b/token_endpoint_assertion_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/lyokato/goidc/authorization"
 	"github.com/lyokato/goidc/grant"
 	th "github.com/lyokato/goidc/test_helper"

--- a/token_endpoint_jwt_test.go
+++ b/token_endpoint_jwt_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt"
 	"github.com/lyokato/goidc/basic_auth"
 	"github.com/lyokato/goidc/grant"
 	th "github.com/lyokato/goidc/test_helper"


### PR DESCRIPTION
### [Why]

Since https://github.com/dgrijalva/jwt-go has already been archived, it will be moved to https://github.com/golang-jwt/jwt, which has taken over maintenance.

See: https://github.com/dgrijalva/jwt-go/issues/462